### PR TITLE
fix(secret)!: change from 'password' to 'passphrase' for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ curl -X GET -H "qsecret-token: my_access_token"
 ## Generating a secret using a token
 To generate a secret, a JSON object needs to be sent to the **/secret** endpoint as a POST, with the following keys:
 **secret**
-**password**
+**passphrase**
 
 Example:
 ```
-curl -d '{"secret":"my secret phrase", "password":"my secret password"}' -H "qsecret-token: access_token" -X POST mysite.com/secret
+curl -d '{"secret":"super secret thing to share", "passphrase":"secret passphrase"}' -H "qsecret-token: access_token" -X POST mysite.com/secret
 ```
 
-If the authentication suceeds, a resulting JSON will come with a **status** and **digest** field. The digest field will return a SHA2 hash which can be used to resolve the secret URL. The URL can be resolved by appending the digest to the end of the URL with the secret endpoint.
+If the authentication succeeds, a resulting JSON will come with a **status** and **digest** field. The digest field will return a SHA2 hash which can be used to resolve the secret URL. The URL can be resolved by appending the digest to the end of the URL with the secret endpoint.
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Quick Secrets - Sublimely Simple Secure Self-Hosted Secret Sharing
+# Quick Secrets - Simple Self-Hosted Secret Sharing
 
 ## What is Quick Secrets?
 

--- a/lib/quick-secrets/secret/manager.rb
+++ b/lib/quick-secrets/secret/manager.rb
@@ -6,7 +6,7 @@ require 'digest'
 module QuickSecrets
   module Secret
     class Manager
-      
+
       AUTH_UUID_LEN_DEFAULT = 8
 
       def initialize
@@ -16,7 +16,7 @@ module QuickSecrets
       def crypt_method
         'AES-256-CBC'
       end
-      
+
       def keys
         @secrets.keys
       end
@@ -39,14 +39,14 @@ module QuickSecrets
         end
         new_uuid
       end
-      
+
       # Stores a secret
-      def store(secret, password)
+      def store(secret, passphrase)
         cipher = OpenSSL::Cipher.new(crypt_method)
         cipher.encrypt
         iv = cipher.random_iv
         cipher.iv = iv
-        cipher.key = Digest::SHA256.digest password
+        cipher.key = Digest::SHA256.digest passphrase
         encrypted = cipher.update(secret)+cipher.final
         #key = Digest::SHA256.hexdigest encrypted
         secret_uuid = gen_uuid()
@@ -58,16 +58,16 @@ module QuickSecrets
       def destroy(uuid)
         @secrets.delete(uuid)
       end
-      
-      
-      def retrieve(uuid, password)
+
+
+      def retrieve(uuid, passphrase)
         if (data = @secrets[uuid]).nil?
           return nil
         else
           cipher = OpenSSL::Cipher.new(crypt_method)
           cipher.decrypt
           cipher.iv = data[:iv]
-          cipher.key = Digest::SHA256.digest password
+          cipher.key = Digest::SHA256.digest passphrase
           begin
             return cipher.update(data[:enc])+cipher.final
           rescue
@@ -75,8 +75,7 @@ module QuickSecrets
           end
         end
       end
-        
+
     end
   end
 end
-

--- a/lib/quick-secrets/web/app.rb
+++ b/lib/quick-secrets/web/app.rb
@@ -34,7 +34,7 @@ module QuickSecrets
       def secrets
         QuickSecrets::Core.core.secrets
       end
-      
+
       # Makes default page the "Create A New Secret Page"
       get '/' do
         auth_web(session, QuickSecrets::Privilege::USER) do
@@ -100,7 +100,7 @@ module QuickSecrets
           erb :account, :locals => {token: auth.get_token(session)}
         end
       end
-      
+
       # Deletes an account
       post '/delete_account/:id' do
         auth_web(session, QuickSecrets::Privilege::ADMIN) do
@@ -167,15 +167,15 @@ module QuickSecrets
       # TODO Refactor, status retval is clunky
       post '/secret/:id' do
         digest = params["id"]
-        password = JSON.parse(request.body.read)["password"]
-        secret = secrets.retrieve(digest,password)
+        passphrase = JSON.parse(request.body.read)["passphrase"]
+        secret = secrets.retrieve(digest,passphrase)
         if status = !secret.nil?
           secrets.destroy(digest)
         end
         {secret: secret, status: status}.to_json
       end
 
-      # Destroy a secret without the password
+      # Destroy a secret without the passphrase
       post '/burn/:id' do
         digest = params["id"]
         if status = secrets.exists?(digest)
@@ -189,10 +189,10 @@ module QuickSecrets
         auth_web(session, QuickSecrets::Privilege::USER) do
           params = JSON.parse request.body.read
           secret = params["secret"]
-          password = params["password"]
-          # TODO make password requirements configurable
-          digest = if secret.length > 0 && password.length > 0
-                     secrets.store(secret,password)
+          passphrase = params["passphrase"]
+          # TODO make passphrase requirements configurable
+          digest = if secret.length > 0 && passphrase.length > 0
+                     secrets.store(secret,passphrase)
                    else
                      nil
                    end

--- a/lib/quick-secrets/web/views/about.md
+++ b/lib/quick-secrets/web/views/about.md
@@ -3,7 +3,7 @@
 ## What is Quick Secrets?
 Quick secrets is a small, portable, web app which allows users to create and share temporary secrets, via generated links.  
 
-Secrets are encrypted using AES-256 encryption and stored in memory. The password used to encrypt the secret and the original secret are not kept. Without the password, a secret cannot be recovered.
+Secrets are encrypted using AES-256 encryption and stored in memory. The passphrase used to encrypt the secret and the original secret are not kept. Without the passphrase, a secret cannot be recovered.
 
 Once a secret is viewed, it is permanently deleted. 
 
@@ -23,13 +23,13 @@ curl -X GET -H "qsecret-token: my_access_token"
 ```
 
 ## Generating a secret using a token
-To generate a secret, a JSON object needs to be sent to the **/secret** endpoint as a POST, with the following keys:  
-**secret**  
-**password**  
+To generate a secret, a JSON object needs to be sent to the **/secret** endpoint as a POST, with the following keys:
+**secret**
+**passphrase**
 
 Example:  
 ```
-curl -d '{"secret":"my secret phrase", "password":"my secret password"}' -H "qsecret-token: access_token" -X POST mysite.com/secret
+curl -d '{"secret":"my secret phrase", "passphrase":"my secret passphrase"}' -H "qsecret-token: access_token" -X POST mysite.com/secret
 ```
 
 If the authentication suceeds, a resulting JSON will come with a **status** and **digest** field. The digest field will return a SHA2 hash which can be used to resolve the secret URL. The URL can be resolved by appending the digest to the end of the URL with the secret endpoint.  

--- a/lib/quick-secrets/web/views/new_secret.erb
+++ b/lib/quick-secrets/web/views/new_secret.erb
@@ -19,15 +19,15 @@
             </small>
           </div>
           <div class="form-group">
-            <label for="password">Enter A Password</label>
-            <input type="password" class="form-control" id="password">
-            <small id="passwordHelp" class="form-text text-danger" style="display: none;">
-              Please enter a password
+            <label for="passphrase">Secret Passphrase</label>
+            <input type="password" class="form-control" id="passphrase">
+            <small id="passphraseHelp" class="form-text text-danger" style="display: none;">
+              Passphrase may not be empty.
             </small>
-            <label for="passwordConfirmation">Confirm Password</label>
-            <input type="password" class="form-control" id="passwordConfirmation">
-            <small id="passwordConfirmationHelp" class="form-text text-danger" style="display: none;">
-              Passwords do not match
+            <label for="passphraseConfirmation">Confirm Passphrase</label>
+            <input type="password" class="form-control" id="passphraseConfirmation">
+            <small id="passphraseConfirmationHelp" class="form-text text-danger" style="display: none;">
+              Secret passphrases do not match.
             </small>
           </div>
           <button id="submit" type="button" class="btn btn-primary">Submit</button>
@@ -49,22 +49,22 @@
 <script>
   var submit = function(){
     let secret = $("#secret").val()
-    let password = $("#password").val()
-    let password_confirm = $("#passwordConfirmation").val()
+    let passphrase = $("#passphrase").val()
+    let passphrase_confirm = $("#passphraseConfirmation").val()
     // Yes I know this is lazy and ugly.
-    if(password.length < 1){
-      $("#password").toggleClass("is-invalid",true);
-      $("#passwordHelp").show();
+    if(passphrase.length < 1){
+      $("#passphrase").toggleClass("is-invalid",true);
+      $("#passphraseHelp").show();
       return;
-    }else if(password_confirm != password) {
-      $("#passwordConfirmation").toggleClass("is-invalid",true);
-      $("#passwordConfirmationHelp").show();
+    }else if(passphrase_confirm != passphrase) {
+      $("#passphraseConfirmation").toggleClass("is-invalid",true);
+      $("#passphraseConfirmationHelp").show();
       return;
     } else{
-      $("#passwordConfirmation").toggleClass("is-invalid",false);
-      $("#passwordConfirmationHelp").hide();
-      $("#password").toggleClass("is-invalid",false);
-      $("#passwordHelp").hide();
+      $("#passphraseConfirmation").toggleClass("is-invalid",false);
+      $("#passphraseConfirmationHelp").hide();
+      $("#passphrase").toggleClass("is-invalid",false);
+      $("#passphraseHelp").hide();
     }
 
     if(secret.length < 1){
@@ -75,12 +75,12 @@
       $("#secret").toggleClass("is-invalid",false);
       $("#secretHelp").hide();
     }
-    axios.post("/secret", { secret: secret, password: password }).then(function(resp){
+    axios.post("/secret", { secret: secret, passphrase: passphrase }).then(function(resp){
       let data = resp.data;
       if(data.status){
         $("#secret").val("");
-        $("#password").val("");
-        $("#passwordConfirmation").val("");
+        $("#passphrase").val("");
+        $("#passphraseConfirmation").val("");
         $("#response").html(`
         <div class="alert alert-success" role="alert">
           <span>Secret Created Successfully!</span><br>
@@ -105,14 +105,14 @@
       submit();
     });
 
-    $("#password").on("keyup", function(e) {
+    $("#passphrase").on("keyup", function(e) {
       e.preventDefault();
       if(e.keyCode == 13) {
         submit();
       }
     });
 
-    $("#passwordConfirmation").on("keyup", function(e) {
+    $("#passphraseConfirmation").on("keyup", function(e) {
       e.preventDefault();
       if(e.keyCode == 13) {
         submit();

--- a/lib/quick-secrets/web/views/secret.erb
+++ b/lib/quick-secrets/web/views/secret.erb
@@ -12,10 +12,10 @@
         <fieldset id="submit_form">
           <form onsubmit="return false;">
             <div class="form-group">
-              <label for="password">Enter A Password</label>
-              <input type="password" class="form-control" id="password">
-              <small id="passwordHelp" class="form-text text-danger" style="display: none;">
-                Please Enter A Password
+              <label for="passphrase">Secret Passphrase</label>
+              <input type="password" class="form-control" id="passphrase">
+              <small id="passphraseHelp" class="form-text text-danger" style="display: none;">
+                Enter the passphrase to decrypt the secret.
               </small>
             </div>
             <button id="submit" type="button" class="btn btn-primary btn-block">Unlock</button>
@@ -72,18 +72,18 @@
   });
   var submit = function(){
     lock();
-    let password = $("#password").val()
+    let passphrase = $("#passphrase").val()
     // Yes I know this is lazy and ugly.
-    if(password.length < 1){
-      $("#password").toggleClass("is-invalid",true);
-      $("#passwordHelp").show();
+    if(passphrase.length < 1){
+      $("#passphrase").toggleClass("is-invalid",true);
+      $("#passphraseHelp").show();
       unlock();
       return;
     }else{
-      $("#password").toggleClass("is-invalid",false);
-      $("#passwordHelp").hide();
+      $("#passphrase").toggleClass("is-invalid",false);
+      $("#passphraseHelp").hide();
     }
-    axios.post(`/secret/<%= digest %>`, {password: password }).then(function(resp){
+    axios.post(`/secret/<%= digest %>`, {passphrase: passphrase }).then(function(resp){
       let data = resp.data;
       if(data.status){
         $("#submit_form").hide()
@@ -102,10 +102,10 @@
         }else{
           $("#response").html(`
           <div class="alert alert-danger" role="alert">
-            <span>Invalid Password</span>
+            <span>Invalid passphrase</span>
           </div>
           `);
-          unlock();  
+          unlock();
         }
       });
   }
@@ -114,7 +114,7 @@
     submit();
   });
 
-  $("#password").on("keyup", function(e) {
+  $("#passphrase").on("keyup", function(e) {
     e.preventDefault();
     console.log(e.keyCode);
     if(e.keyCode == 13) {


### PR DESCRIPTION
This differentiates between "Passwords", used to authenticate access to the app,
and "Passphrases", which are used to encrypt/decrypt secrets.

The API parameters also change from 'password' to 'passphrase' for secret generation/decryption.

FIXES: #6