### PR TITLE
Add the ability to store secrets in the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An account is required to create secrets.  This enables organizations to host th
 
 ## How are secrets stored securely?
 
-Once a secret is entered and submitted, the secret is encrypted using AES-256 and stored **only** in memory, never written to disk.  Neither the secret passphrase used to encrypt the secret, nor the original plaintext secret are kept.  Without the secret passphrase, a secret cannot be recovered, even by the owner of the system hosting the application.
+Once a secret is entered and submitted, the secret is encrypted using AES-256 and can be configured to be stored **only** in memory or written to the database disk.  Neither the secret passphrase used to encrypt the secret, nor the original plaintext secret are kept.  Without the secret passphrase, a secret cannot be recovered, even by the owner of the system hosting the application.
 
 # Installation
 
@@ -107,6 +107,7 @@ Quick secrets can be configured via configuration file or by environment variabl
 | `QUICK_SECRETS_ADMIN_PASSWORD` | The default admin password, stored as a SHA256 hash | 65c21921ca10a8502757efc9aa552874d181c6206feb2845a921eb57f5e518d4  (this is `password1!`) |
 | `QUICK_SECRETS_CONFIG` | The location of the `config.yml` | /etc/quick_secrets/config.yml |
 | `QUICK_SECRETS_SECRET_UUID_LENGTH` | The length of the UUID used to create a link to a secret | 8 |
+| `QUICK_SECRETS_STORE_SECRETS` | The length of the UUID used to create a link to a secret | False |
 
 # Scripting
 

--- a/lib/quick-secrets/core.rb
+++ b/lib/quick-secrets/core.rb
@@ -59,6 +59,7 @@ module QuickSecrets
         db.create_table :secret do
           primary_key :id
           String :uuid
+          String :expiration_date
           Blob :initialization_vector
           Blob :encrypted_data
         end

--- a/lib/quick-secrets/core.rb
+++ b/lib/quick-secrets/core.rb
@@ -55,6 +55,14 @@ module QuickSecrets
           Integer :account_id
         end
       end
+      unless db.table_exists? :secret
+        db.create_table :secret do
+          primary_key :id
+          String :uuid
+          Blob :initialization_vector
+          Blob :encrypted_data
+        end
+      end
     end
 
 

--- a/lib/quick-secrets/secret/manager.rb
+++ b/lib/quick-secrets/secret/manager.rb
@@ -18,16 +18,44 @@ module QuickSecrets
       end
       
       def keys
-        @secrets.keys
+        if store_secrets?
+          qs_db[:secret].select(:uuid).all.map{|e| e[:uuid]}
+        else
+          @secrets.keys
+        end
+      end
+
+      def size
+        if store_secrets?
+          qs_db[:secret].count
+        else
+          keys.size
+        end
+      end
+
+      def qs_db
+        QuickSecrets::Core.core.db
       end
 
       def exists?(uuid)
-        @secrets.key? uuid
+        if store_secrets?
+          return true unless qs_db[:secret].where(uuid: uuid).first.nil?
+        else
+          @secrets.key? uuid
+        end
+      end
+
+      def qs_config
+        QuickSecrets::Core.core.config
+      end
+
+      def store_secrets?
+        qs_config['store_secrets']
       end
 
       # get the length for secret UUID's used in URL's
       def uuid_len
-        QuickSecrets::Core.core.config["secret_uuid_length"]&.to_i || AUTH_UUID_LEN_DEFAULT
+        qs_config["secret_uuid_length"]&.to_i || AUTH_UUID_LEN_DEFAULT
       end
 
       # Generate a UUID for the secret's URL
@@ -35,7 +63,7 @@ module QuickSecrets
         new_uuid = nil
         loop do
           new_uuid = SecureRandom.alphanumeric(uuid_len)
-        break unless exists?(new_uuid)
+          break unless exists?(new_uuid)
         end
         new_uuid
       end
@@ -50,29 +78,39 @@ module QuickSecrets
         encrypted = cipher.update(secret)+cipher.final
         #key = Digest::SHA256.hexdigest encrypted
         secret_uuid = gen_uuid()
-        @secrets[secret_uuid] = {iv: iv, enc: encrypted}
+        if store_secrets?
+          qs_db[:secret].insert(uuid: secret_uuid, initialization_vector: iv, encrypted_data: encrypted)
+        else
+          @secrets[secret_uuid] = {initialization_vector: iv, encrypted_data: encrypted}
+        end
         return secret_uuid
       end
 
       # Destroys a secret
       def destroy(uuid)
-        @secrets.delete(uuid)
+        if store_secrets?
+          qs_db[:secret].where(uuid: uuid).delete
+        else
+          @secrets.delete(uuid)
+        end
       end
       
       
       def retrieve(uuid, password)
-        if (data = @secrets[uuid]).nil?
-          return nil
-        else
-          cipher = OpenSSL::Cipher.new(crypt_method)
-          cipher.decrypt
-          cipher.iv = data[:iv]
-          cipher.key = Digest::SHA256.digest password
-          begin
-            return cipher.update(data[:enc])+cipher.final
-          rescue
-            nil
-          end
+        return nil unless exists?(uuid)
+        data = if store_secrets?
+                 qs_db[:secret].where(uuid: uuid).first
+               else
+                 @secrets[uuid]
+               end
+        cipher = OpenSSL::Cipher.new(crypt_method)
+        cipher.decrypt
+        cipher.iv = data[:initialization_vector]
+        cipher.key = Digest::SHA256.digest password
+        begin
+          return cipher.update(data[:encrypted_data])+cipher.final
+        rescue
+          nil
         end
       end
         

--- a/lib/quick-secrets/secret/manager.rb
+++ b/lib/quick-secrets/secret/manager.rb
@@ -79,7 +79,7 @@ module QuickSecrets
         #key = Digest::SHA256.hexdigest encrypted
         secret_uuid = gen_uuid()
         if store_secrets?
-          qs_db[:secret].insert(uuid: secret_uuid, initialization_vector: iv, encrypted_data: encrypted)
+          qs_db[:secret].insert(uuid: secret_uuid, initialization_vector: iv, encrypted_data: encrypted, expiration_date: nil)
         else
           @secrets[secret_uuid] = {initialization_vector: iv, encrypted_data: encrypted}
         end

--- a/lib/quick-secrets/templates/config.yml
+++ b/lib/quick-secrets/templates/config.yml
@@ -7,6 +7,8 @@ url: http://mysite.com
 listen_address: "0.0.0.0"
 listen_port: 8080
 
+store_secrets: True
+
 # Time until session expires in seconds
 session_expiration: 300
 

--- a/lib/quick-secrets/templates/config.yml
+++ b/lib/quick-secrets/templates/config.yml
@@ -7,7 +7,7 @@ url: http://mysite.com
 listen_address: "0.0.0.0"
 listen_port: 8080
 
-store_secrets: True
+store_secrets: False
 
 # Time until session expires in seconds
 session_expiration: 300

--- a/lib/quick-secrets/web/app.rb
+++ b/lib/quick-secrets/web/app.rb
@@ -20,6 +20,11 @@ module QuickSecrets
         QuickSecrets::Core.core.authenticator
       end
 
+      # Secrets Manager
+      def secrets
+        QuickSecrets::Core.core.secrets
+      end
+
       # Wrapper method which checks permissions for an action.
       def auth_web(session, perm)
         session["token"] = request.env["HTTP_QSECRET_TOKEN"]
@@ -30,11 +35,6 @@ module QuickSecrets
         end
       end
 
-      # secrets hash
-      def secrets
-        QuickSecrets::Core.core.secrets
-      end
-      
       # Makes default page the "Create A New Secret Page"
       get '/' do
         auth_web(session, QuickSecrets::Privilege::USER) do
@@ -65,7 +65,7 @@ module QuickSecrets
 
       get '/secret/list' do
         auth_web(session, QuickSecrets::Privilege::ADMIN) do
-          QuickSecrets::Core.core.secrets.keys.to_json
+          secrets.keys.to_json
         end
       end
 

--- a/lib/quick-secrets/web/views/admin.erb
+++ b/lib/quick-secrets/web/views/admin.erb
@@ -13,7 +13,7 @@
             <table class="table">
               <thead></thead>
               <tr>
-                <td>Active Secrets: <%= QuickSecrets::Core.core.secrets.keys.size %></td>
+                <td>Active Secrets: <%= QuickSecrets::Core.core.secrets.size %></td>
               </tr>
             </table>
           </div>


### PR DESCRIPTION
This PR adds the ability to store secrets in the database, allowing for persistence during restarts.  

This is done via the `store_secrets` configuration option

Resolves #36 