### PR TITLE
Fix #39

### DIFF
--- a/lib/quick-secrets/secret/manager.rb
+++ b/lib/quick-secrets/secret/manager.rb
@@ -79,17 +79,12 @@ module QuickSecrets
         #key = Digest::SHA256.hexdigest encrypted
         secret_uuid = gen_uuid()
         if store_secrets?
-          begin
             db_iv = iv.unpack('H*')[0]
             db_data = encrypted.unpack('H*')[0]
             qs_db[:secret].insert(uuid: secret_uuid, 
                                   initialization_vector: db_iv, 
                                   encrypted_data: db_data, 
                                   expiration_date: nil)
-          rescue => error
-            require 'pry'
-            binding.pry
-          end
         else
           @secrets[secret_uuid] = {initialization_vector: iv, encrypted_data: encrypted}
         end


### PR DESCRIPTION
#39 highlights a serious issue where submitting passwords with a persistent secret store causes a non-idempotent error and fails. The problem was the binary data representing the encrypted secret is not always valid to submit to a sqlite database. I had thought this was fixed by using the `Blob` type for the database, but I was mistaken. Sqlite simply cannot handle it.  

To fix this, I've moved the storage to a string type, and cast the bytes' hex value as a string. This is the raw data for the encrypted data. So here's an example:
```
{:id=>10,
  :uuid=>"Rbn9iqvj",
  :expiration_date=>nil,
  :initialization_vector=>"1a8505e8214a96e7ed6ffa8d3ebed1c6",
  :encrypted_data=>"c668e60e6fb31392635677546c944b57"},
}
``` 
This is an entry with the password being `ok`.  

With this encoding, we won't run into anymore complaints from sqlite, as it's just a string with only [a-f0-9] characters.  

Secondly, there is a migration script to handle any databases that are currently affected by this. If you have a DB that suffers from this bug, on next startup your secrets will be migrated and stored appropriately